### PR TITLE
add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && \
+    apt-get install -y wget unzip curl expect && \
+    mkdir -p /app && \
+    wget -O /app/covid-linux.zip "https://github.com/gasperTheGhost/covid-solver-unix/releases/latest/download/covid-linux.zip" && \
+    unzip /app/covid-linux.zip -d /app
+
+WORKDIR /app
+
+COPY docker-run.sh /app
+RUN chmod +x /app/docker-run.sh
+ENTRYPOINT ["/app/docker-run.sh"]
+
+# Threads, Priority: -20 (highest) - 19 (lowest), RxDock output files
+CMD ["All", "0", "no"]

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/expect -f
+
+set force_conservative 0
+if {$force_conservative} {
+        set send_slow {1 .1}
+        proc send {ignore arg} {
+                sleep .1
+                exp_send -s -- $arg
+        }
+}
+
+set THREADS [lindex $argv 0]
+set PRIORITY [lindex $argv 1]
+set OUTPUT_FILES_SAVE [lindex $argv 2]
+
+set timeout -1
+spawn ./covid-solver
+match_max 100000
+send -- "\r"
+expect -re ".*Please enter how many threads you would like this software to use.*"
+send -- "$THREADS\r"
+expect -re ".*priority for this software.*"
+send -- "$PRIORITY\r"
+expect -re ".*keep the RxDock output files?.*"
+send -- "$OUTPUT_FILES_SAVE\r\n"
+
+expect -re ".*Newer version of script found.*"
+send -- "Yes\r"
+
+interact
+expect eof


### PR DESCRIPTION
Created Dockefile along with an expect script that will automatically fill out the data that is asked interactively. Not the best solution but it works.

It would be better if it would be possible to pass data that is asked interactively via arguments than the script I created that uses `expect`.

So far it works on two servers that I am running.

How to build:
Docker is a prerequisites 
```bash
sudo docker build -t covid-solver .
sudo docker run --name covid-solver -d covid-solver
```